### PR TITLE
Made plugins get_list follow pagination

### DIFF
--- a/kong/__init__.py
+++ b/kong/__init__.py
@@ -1,3 +1,3 @@
 """Asynchronous Kong client"""
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'

--- a/kong/components.py
+++ b/kong/components.py
@@ -52,8 +52,8 @@ class CrudComponent(Component):
             self.url, params=as_params(**params), wrap=self.wrap_list
         )
 
-    async def paginate(self, **params):
-        next_ = self.url
+    async def paginate(self, url: str = None, **params):
+        next_ = url or self.url
         params = as_params(**params)
         while next_:
             data = await self.execute(next_, params=params)

--- a/kong/plugins.py
+++ b/kong/plugins.py
@@ -10,9 +10,9 @@ class PluginMixin:
     def url(self) -> str:
         return '%s/%s' % (self.cli.url, self.name)
 
-    def get_list(self, **params):
+    async def get_list(self, **params):
         url = '%s/%s' % (self.root.url, self.name)
-        return self.execute(url, params=params, wrap=self.wrap_list)
+        return [plugin async for plugin in self.paginate(url, **params)]
 
     async def apply_json(self, data, **kwargs):
         if not isinstance(data, list):


### PR DESCRIPTION
Fixed issue with kong-config not seeing already present plugins due to pagination.
This is branched from 9208767, we need a new base for merge to maintain compatibility with Kong < 1.0.