### PR TITLE
FIx usage example in the documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ In a coroutine:
 ```python
 async with Kong() as cli:
     services = await cli.services.get_list()
-    print(json.dumps(services, indent=4))
+    print(json.dumps([s.data for s in services], indent=4))
 ```
 The client has handlers for all Kong objects
 


### PR DESCRIPTION
The usage in the documentation is invalid (tested with version 0.5.3), it fails with :
```
TypeError: Object of type Service is not JSON serializable
```
Replacing the list of Services with a list of Service data solves the serialization issue