### PR TITLE
Add ability to update exisiting credentials, instead of failing with a 409

### DIFF
--- a/kong/auths.py
+++ b/kong/auths.py
@@ -24,7 +24,7 @@ class ConsumerAuth(CrudComponent):
         try:
             return next(cred for cred
                         in await self.get_list()
-                        if cred.get(self.unique_field, None) == cur_unique)['id']
+                        if cred[self.unique_field] == cur_unique)['id']
         except StopIteration:
             return None
 

--- a/kong/auths.py
+++ b/kong/auths.py
@@ -1,0 +1,66 @@
+from .components import CrudComponent
+
+
+def auth_factory(consumer, auth_type):
+    known_types = {'basic-auth': BasicAuth,
+                   'key-auth': KeyAuth}
+    constructor = known_types.get(auth_type, ConsumerAuth)
+    return constructor(consumer, auth_type)
+
+
+class ConsumerAuth(CrudComponent):
+
+    unique_field = None
+
+    @property
+    def url(self) -> str:
+        return f'{self.root.url}/{self.name}'
+
+    async def get_existing_id(self, creds_config):
+        if not self.unique_field:
+            raise NotImplementedError('Existence check not implemented for this type of\
+                 authentication')
+        cur_unique = creds_config[self.unique_field]
+        try:
+            return next(cred for cred
+                        in await self.get_list()
+                        if cred.get(self.unique_field, None) == cur_unique)['id']
+        except StopIteration:
+            return None
+
+    async def create_or_update_credentials(self, creds_config):
+        existing_id = await self.get_existing_id(creds_config)
+        if existing_id:
+            await self.update_credentials(id_=existing_id, data=creds_config)
+        else:
+            await self.create_credentials(data=creds_config)
+
+    async def update_credentials(self, id_, **kw):
+        url = f'{self.url}/{id_}'
+
+        return await self.cli.execute(
+            url, 'patch',
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            wrap=self.wrap,
+            **kw
+        )
+
+    async def create_credentials(self, **kw):
+        return await self.cli.execute(
+            self.url, 'post',
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            wrap=self.wrap,
+            **kw
+        )
+
+    async def get_or_create(self):
+        secrets = await self.get_list(limit=1)
+        return secrets[0] if secrets else await self.create()
+
+
+class BasicAuth(ConsumerAuth):
+    unique_field = 'username'
+
+
+class KeyAuth(ConsumerAuth):
+    unique_field = 'key'

--- a/kong/consumers.py
+++ b/kong/consumers.py
@@ -1,11 +1,17 @@
 from .components import CrudComponent, KongError
 from .plugins import KongEntityWithPlugins
+from .auths import auth_factory
 
 
 class Consumers(CrudComponent):
 
     def wrap(self, data):
         return Consumer(self, data)
+
+    async def apply_credentials(self, auths, consumer):
+        for auth_data in auths:
+            auth = auth_factory(consumer, auth_data['type'])
+            await auth.create_or_update_credentials(auth_data['config'])
 
     async def apply_json(self, data):
         if not isinstance(data, list):
@@ -45,32 +51,11 @@ class Consumers(CrudComponent):
             for acl in current_groups.values():
                 await consumer.acls.delete(acl['id'])
 
-            for auth_data in auths:
-                auth = ConsumerAuth(consumer, auth_data['type'])
-                await auth.create(data=auth_data.get('config', {}))
+            await self.apply_credentials(auths, consumer)
 
             result.append(consumer.data)
 
         return result
-
-
-class ConsumerAuth(CrudComponent):
-
-    @property
-    def url(self) -> str:
-        return f'{self.root.url}/{self.name}'
-
-    async def create(self, **kw):
-        return await self.cli.execute(
-            self.url, 'POST',
-            headers={'Content-Type': 'application/x-www-form-urlencoded'},
-            wrap=self.wrap,
-            **kw
-        )
-
-    async def get_or_create(self):
-        secrets = await self.get_list(limit=1)
-        return secrets[0] if secrets else await self.create()
 
 
 class Consumer(KongEntityWithPlugins):
@@ -85,12 +70,12 @@ class Consumer(KongEntityWithPlugins):
 
     @property
     def jwts(self):
-        return ConsumerAuth(self, 'jwt')
+        return auth_factory(self, 'jwt')
 
     @property
     def keyauths(self):
-        return ConsumerAuth(self, 'key-auth')
+        return auth_factory(self, 'key-auth')
 
     @property
     def basicauths(self):
-        return ConsumerAuth(self, 'basic-auth')
+        return auth_factory(self, 'basic-auth')

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -81,24 +81,31 @@ async def test_json_route_plugins(cli):
 
 
 async def test_auth_handling(cli):
-    with open(os.path.join(PATH, 'test_basic_auth.yaml')) as fp:
+    with open(os.path.join(PATH, 'test_auth.yaml')) as fp:
         await cli.apply_json(yaml.load(fp))
     consumer = await cli.consumers.get('admin')
-    auths = await consumer.basicauths.get_list()
-    assert len(auths) == 1
-    assert auths[0]['username'] == 'admin_creds'
+
+    basic_auths = await consumer.basicauths.get_list()
+    assert len(basic_auths) == 1
+    assert basic_auths[0]['username'] == 'admin_creds'
+
+    key_auths = await consumer.keyauths.get_list()
+    assert len(key_auths) == 1
 
 
 async def test_auth_overwrite(cli):
-    with open(os.path.join(PATH, 'test_basic_auth.yaml')) as fp:
+    with open(os.path.join(PATH, 'test_auth.yaml')) as fp:
         await cli.apply_json(yaml.load(fp))
     with open(os.path.join(PATH, 'test_auth_overwrite.yaml')) as fp:
         await cli.apply_json(yaml.load(fp))
     consumer = await cli.consumers.get('admin')
-    auths = await consumer.basicauths.get_list()
-    assert len(auths) == 1
-    assert auths[0]['username'] == 'admin_creds'
 
+    basic_auths = await consumer.basicauths.get_list()
+    assert len(basic_auths) == 1
+    assert basic_auths[0]['username'] == 'admin_creds'
+
+    key_auths = await consumer.keyauths.get_list()
+    assert len(key_auths) == 1
 
 async def test_ensure_remove(cli):
     with open(os.path.join(PATH, 'test6.yaml')) as fp:

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -89,6 +89,17 @@ async def test_auth_handling(cli):
     assert auths[0]['username'] == 'admin_creds'
 
 
+async def test_auth_overwrite(cli):
+    with open(os.path.join(PATH, 'test_basic_auth.yaml')) as fp:
+        await cli.apply_json(yaml.load(fp))
+    with open(os.path.join(PATH, 'test_auth_overwrite.yaml')) as fp:
+        await cli.apply_json(yaml.load(fp))
+    consumer = await cli.consumers.get('admin')
+    auths = await consumer.basicauths.get_list()
+    assert len(auths) == 1
+    assert auths[0]['username'] == 'admin_creds'
+
+
 async def test_ensure_remove(cli):
     with open(os.path.join(PATH, 'test6.yaml')) as fp:
         await cli.apply_json(yaml.load(fp))

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -107,6 +107,7 @@ async def test_auth_overwrite(cli):
     key_auths = await consumer.keyauths.get_list()
     assert len(key_auths) == 1
 
+
 async def test_ensure_remove(cli):
     with open(os.path.join(PATH, 'test6.yaml')) as fp:
         await cli.apply_json(yaml.load(fp))

--- a/tests/test_auth.yaml
+++ b/tests/test_auth.yaml
@@ -5,3 +5,6 @@ consumers:
         config:
           username: admin_creds
           password: hunter2
+      - type: key-auth
+        config:
+          key: DonKeyKong

--- a/tests/test_auth_overwrite.yaml
+++ b/tests/test_auth_overwrite.yaml
@@ -1,0 +1,7 @@
+consumers:
+  - username: admin
+    auths:
+      - type: basic-auth
+        config:
+          username: admin_creds
+          password: hunter3

--- a/tests/test_auth_overwrite.yaml
+++ b/tests/test_auth_overwrite.yaml
@@ -5,3 +5,6 @@ consumers:
         config:
           username: admin_creds
           password: hunter3
+      - type: key-auth
+        config:
+          key: DonKeyKong


### PR DESCRIPTION
The previous version of credential creation failed with a 409 (UNIQUE violation detected) when trying to update an existing credential, or replaying a yaml file on a previously initialized kong installation.

This PR allows to update the credential instead.

As a side note, update only works for credentials for the same consumer. I.E., trying to create a basic-auth credential with username admin for consumer1 when a basic-auth credential with username admin already exists for consumer2 still fails, as I believe would be expected.